### PR TITLE
feat: add home page

### DIFF
--- a/src/main/java/andrei/chirila/prove_yourself/infrastructure/config/WebSecurityConfig.java
+++ b/src/main/java/andrei/chirila/prove_yourself/infrastructure/config/WebSecurityConfig.java
@@ -90,7 +90,7 @@ public class WebSecurityConfig {
                                         .build();
 
                                 response.addHeader(HttpHeaders.SET_COOKIE, expiredCookie.toString());
-                                response.setStatus(HttpStatus.OK.value());
+                                response.sendRedirect(WebSecurityConfig.WELCOME_URL_MATCHER);
                             });
                 })
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/andrei/chirila/prove_yourself/infrastructure/config/WebSecurityConfig.java
+++ b/src/main/java/andrei/chirila/prove_yourself/infrastructure/config/WebSecurityConfig.java
@@ -3,15 +3,15 @@ package andrei.chirila.prove_yourself.infrastructure.config;
 import andrei.chirila.prove_yourself.domain.Role;
 import andrei.chirila.prove_yourself.domain.services.AuthService;
 import andrei.chirila.prove_yourself.infrastructure.filters.JwtAuthenticationFilter;
-import jakarta.servlet.Filter;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import org.aopalliance.intercept.MethodInvocation;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
 import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
@@ -26,11 +26,10 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.logout.LogoutFilter;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 
 @Configuration
@@ -42,6 +41,12 @@ public class WebSecurityConfig {
     private final PasswordEncoder passwordEncoder;
     @Value("${cookie.name}")
     private String cookieName;
+    @Value("${cookie.http-only}")
+    private boolean cookieHttpOnly;
+    @Value("${cookie.same-site}")
+    private String cookieSameSite;
+    @Value("${cookie.path}")
+    private String cookiePath;
 
     public WebSecurityConfig(AuthService authService, UserDetailsService userDetailsService, PasswordEncoder passwordEncoder) {
         this.authService = authService;
@@ -60,9 +65,7 @@ public class WebSecurityConfig {
     final String BASE_URL_MATCHER = ApiConfig.API_BASE_PATH + "/**";
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws  Exception {
-        final Filter jwtFilter = jwtAuthenticationFilter();
-
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtAuthenticationFilter jwtFilter) throws  Exception {
         http
                 .authorizeHttpRequests((requests) -> requests
                         .requestMatchers("/css/**").permitAll()
@@ -76,15 +79,21 @@ public class WebSecurityConfig {
                 )
                 .logout(logout -> {
                     logout
-                            .logoutRequestMatcher(PathPatternRequestMatcher.pathPattern(HttpMethod.POST, LOGOUT_URL_MATCHER))
+                            .logoutRequestMatcher(PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.POST, LOGOUT_URL_MATCHER))
                             .logoutSuccessHandler((request, response, authentication) -> {
-                                response.setStatus(HttpStatus.NO_CONTENT.value());
-                                final Cookie cookie = new Cookie(cookieName, null);
-                                cookie.setMaxAge(0);
-                                response.addCookie(cookie);
+                                ResponseCookie expiredCookie = ResponseCookie.from(cookieName, "")
+                                        .httpOnly(cookieHttpOnly)
+                                        .secure(false)
+                                        .maxAge(0)
+                                        .sameSite(cookieSameSite)
+                                        .path(cookiePath)
+                                        .build();
+
+                                response.addHeader(HttpHeaders.SET_COOKIE, expiredCookie.toString());
+                                response.setStatus(HttpStatus.OK.value());
                             });
                 })
-                .addFilterBefore(jwtFilter, LogoutFilter.class)
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement((sm) -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .oauth2ResourceServer((oauth2) -> oauth2.jwt(Customizer.withDefaults()))
@@ -124,9 +133,5 @@ public class WebSecurityConfig {
                 .role(Role.ADMIN.name())
                 .implies(Role.USER.name())
                 .build();
-    }
-
-    private JwtAuthenticationFilter jwtAuthenticationFilter() {
-        return new JwtAuthenticationFilter(authService, userDetailsService);
     }
 }

--- a/src/main/java/andrei/chirila/prove_yourself/infrastructure/controllers/AuthController.java
+++ b/src/main/java/andrei/chirila/prove_yourself/infrastructure/controllers/AuthController.java
@@ -5,16 +5,15 @@ import andrei.chirila.prove_yourself.infrastructure.config.ApiConfig;
 import andrei.chirila.prove_yourself.infrastructure.config.WebSecurityConfig;
 import andrei.chirila.prove_yourself.infrastructure.dtos.CreateUserDto;
 import andrei.chirila.prove_yourself.infrastructure.dtos.LoginRequestDto;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.view.FragmentsRendering;
@@ -35,6 +34,8 @@ public class AuthController {
     private int cookieMaxAge;
     @Value("${cookie.same-site}")
     private String cookieSameSite;
+    @Value("${cookie.path}")
+    private String cookiePath;
 
     public AuthController(AuthService authService) {
         this.authService = authService;
@@ -44,16 +45,10 @@ public class AuthController {
     @ResponseBody
     public void login(@Valid LoginRequestDto loginRequestDto, HttpServletResponse response) {
         final String token = authService.login(loginRequestDto);
-        final Cookie cookie = createAuthCookie(token);
-        response.addCookie(cookie);
-        response.addHeader("HX-Redirect", WebSecurityConfig.HOME_URL_MATCHER);
-    }
-
-    @PostMapping("/logout")
-    @ResponseBody
-    public void logout(HttpServletResponse response) {
-        final Cookie cookie = new Cookie(cookieName, StringUtils.EMPTY);
-        cookie.setMaxAge(0);
+        final ResponseCookie cookie = createAuthCookie(token);
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+        response.setStatus(HttpServletResponse.SC_FOUND);
+        response.setHeader("Location", WebSecurityConfig.HOME_URL_MATCHER);
     }
 
     @GetMapping("/register")
@@ -77,14 +72,13 @@ public class AuthController {
         return "site/verification";
     }
 
-    private Cookie createAuthCookie(String token) {
-        final String SAME_SITE_KEY = "SameSite";
-        final Cookie cookie = new Cookie(cookieName, token);
-        cookie.setHttpOnly(cookieHttpOnly);
-        cookie.setSecure(cookieSecure);
-        cookie.setMaxAge(cookieMaxAge);
-        cookie.setAttribute(SAME_SITE_KEY, cookieSameSite);
-
-        return cookie;
+    private ResponseCookie createAuthCookie(String token) {
+        return ResponseCookie.from(cookieName, token)
+                .httpOnly(cookieHttpOnly)
+                .secure(cookieSecure)
+                .maxAge(cookieMaxAge)
+                .sameSite(cookieSameSite)
+                .path(cookiePath)
+                .build();
     }
 }

--- a/src/main/java/andrei/chirila/prove_yourself/infrastructure/controllers/SiteController.java
+++ b/src/main/java/andrei/chirila/prove_yourself/infrastructure/controllers/SiteController.java
@@ -20,7 +20,12 @@ public class SiteController {
     }
 
     @GetMapping("/home")
-    public String home() {
+    public String home(Model model) {
+        model.addAttribute("projectsPath", ApiConfig.API_BASE_PATH + "/projects");
+        model.addAttribute("profilePath", ApiConfig.API_BASE_PATH + "/profile");
+        model.addAttribute("settingsPath", ApiConfig.API_BASE_PATH + "/account-settings");
+        model.addAttribute("logoutPath", WebSecurityConfig.LOGOUT_URL_MATCHER);
+
         return "site/home";
     }
 }

--- a/src/main/java/andrei/chirila/prove_yourself/infrastructure/filters/JwtAuthenticationFilter.java
+++ b/src/main/java/andrei/chirila/prove_yourself/infrastructure/filters/JwtAuthenticationFilter.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 @Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private static final Logger logger = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
-    private static final List<String> URL_MATCHERS = List.of(WebSecurityConfig.WELCOME_URL_MATCHER, WebSecurityConfig.LOGIN_URL_MATCHER, WebSecurityConfig.REGISTRATION_URL_MATCHER, WebSecurityConfig.CREATE_USER_URL_MATCHER, WebSecurityConfig.ACCOUNT_VERIFICATION_URL_MATCHER, "/css/prove.css");
+    private static final List<String> URL_MATCHERS = List.of(WebSecurityConfig.WELCOME_URL_MATCHER, WebSecurityConfig.LOGIN_URL_MATCHER, WebSecurityConfig.REGISTRATION_URL_MATCHER, WebSecurityConfig.CREATE_USER_URL_MATCHER, WebSecurityConfig.ACCOUNT_VERIFICATION_URL_MATCHER, WebSecurityConfig.LOGOUT_URL_MATCHER, "/css/prove.css");
     private final AuthService authService;
     private final UserDetailsService userDetailsService;
     @Value("${cookie.name}")

--- a/src/main/java/andrei/chirila/prove_yourself/infrastructure/filters/JwtAuthenticationFilter.java
+++ b/src/main/java/andrei/chirila/prove_yourself/infrastructure/filters/JwtAuthenticationFilter.java
@@ -11,7 +11,11 @@ import jakarta.validation.constraints.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.thymeleaf.util.ArrayUtils;
 
@@ -20,6 +24,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+@Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private static final Logger logger = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
     private static final List<String> URL_MATCHERS = List.of(WebSecurityConfig.WELCOME_URL_MATCHER, WebSecurityConfig.LOGIN_URL_MATCHER, WebSecurityConfig.REGISTRATION_URL_MATCHER, WebSecurityConfig.CREATE_USER_URL_MATCHER, WebSecurityConfig.ACCOUNT_VERIFICATION_URL_MATCHER, "/css/prove.css");
@@ -36,21 +41,42 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(@NotNull HttpServletRequest request, @NotNull HttpServletResponse response, @NotNull FilterChain filterChain) throws ServletException, IOException {
         final Optional<String> token = getJwtFromCookie(request);
+
+        if (token.isEmpty()) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        if (!authService.validateToken(token.get())) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            logger.warn("[AUTH] : Token is invalid for request: {}", request.getRequestURI());
+            return;
+        }
+
+        String userName = authService.getUserFromToken(token.get());
+        UserDetails userDetails = userDetailsService.loadUserByUsername(userName);
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+        authenticationToken.setDetails(userDetails);
+        SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+        logger.info("[AUTH] : Request successfully authorized for user: {}", userName);
+
+        filterChain.doFilter(request, response);
     }
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         final String requestURI = request.getRequestURI();
-
         return URL_MATCHERS.contains(requestURI);
     }
 
     private Optional<String> getJwtFromCookie(HttpServletRequest request) {
         final Cookie[] cookies = request.getCookies();
+
         if (cookies == null || ArrayUtils.isEmpty(cookies)) {
             return Optional.empty();
         }
-        
+
         return (Arrays.stream(cookies)
                 .filter(cookie -> cookie.getName().equals(cookieName))
                 .map(Cookie::getValue)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,43 +1,34 @@
 spring.application.name=prove-yourself
-
 # JPA Configuration
-spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.PostgreSQLDialect
-spring.jpa.hibernate.ddl-auto = create-drop
-spring.jpa.hibernate.show-sql = true
-
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.hibernate.show-sql=true
 # DATASOURCE (Local Environment)
-spring.datasource.url = jdbc:postgresql://localhost:5432/prove-yourself
-spring.datasource.username = ${DB_USERNAME}
-spring.datasource.password = ${DB_PASSWORD}
-
+spring.datasource.url=jdbc:postgresql://localhost:5432/prove-yourself
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
 # DISABLE FLYWAY (UNTIL NEEDED)
-spring.flyway.enabled = false
-
+spring.flyway.enabled=false
 # DISABLE DOCKER COMPOSE (FOR NOW)
-spring.docker.compose.enabled = false
-
+spring.docker.compose.enabled=false
 # JWT CONFIGURATION
-jwt.secret = ${JWT_SECRET}
-jwt.expiration = 15
-
+jwt.secret=${JWT_SECRET}
+jwt.expiration=15
 # Cookie CONFIGURATION
-cookie.name = auth-token
-cookie.http-only = true
-cookie.secure = true
-cookie.max-age = 720
-cookie.same-site = Strict
-
-
+cookie.name=auth-token
+cookie.http-only=true
+cookie.secure=false
+cookie.max-age=720
+cookie.same-site=Lax
+cookie.path=/
 # LOGGING
 #logging.level.org.springframework.security = DEBUG
 # MULTIPART CONFIGURATION (LIMITING FILE UPLOAD SIZE)
 spring.servlet.multipart.max-file-size=2MB
-
 # THYMELEAF
 spring.thymeleaf.cache=false
 spring.thymeleaf.prefix=classpath:/templates/
 spring.thymeleaf.suffix=.html
-
 # EMAIL
 spring.mail.host=smtp.gmail.com
 spring.mail.port=587

--- a/src/main/resources/templates/site/home.html
+++ b/src/main/resources/templates/site/home.html
@@ -1,10 +1,32 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=1.0">
+    <link rel="stylesheet" href="/css/prove.css" th:href="@{/css/prove.css}">
     <title>Home</title>
 </head>
 <body>
+<nav>
+    <ul>
+        <li><b>Exhibition Land</b></li>
+    </ul>
+    <ul>
+        <li><a th:href="${projectsPath}" class="secondary">Projects</a></li>
+        <li>
+            <details class="dropdown">
+                <summary>
+                    Account
+                </summary>
+                <ul dir="rtl">
+                    <li><a th:href="${profilePath}">Profile</a></li>
+                    <li><a th:href="${settingsPath}">Settings</a></li>
+                    <li><button type=submit form="logout-form">Logout</button></li>
+                </ul>
+            </details>
+        </li>
+    </ul>
+</nav>
+<form id="logout-form" method="post" th:action="${logoutPath}" style="display: none;"></form>
 </body>
 </html>

--- a/src/main/resources/templates/site/welcome.html
+++ b/src/main/resources/templates/site/welcome.html
@@ -14,7 +14,7 @@
         <header style="text-align: center">
             Login
         </header>
-        <form id="login-form" th:hx-post="${loginPath}">
+        <form id="login-form" method="post" th:action="${loginPath}">
             <fieldset>
                 <label>
                     Email


### PR DESCRIPTION
* Added a home page (demo) - only the logout function is implemented, rest of pages will be implemented later and then this will be updated;
* Added logout flow, deletion of cookie and redirecting the user properly;
* Dropped **htmx** approach on the login and went for a classic form submission for proper functionality. htmx was more of an overheard for this specific functionality to log in an user;
* Corrected a typo in the security filter chain method to correctly use the username and password filter class and not the logout filter class - for the **addFilterBefore** method;
* Properly implemented the **doFilterInternal** method to authenticate requests that have a valid token, or deny access in case of invalid token. Requests that are not required to be filtered will just pass normally (they are added in the **shouldNotFilter**), so no checking of token validity will take place (register, verification of email, welcome page... for example);